### PR TITLE
removing characters breaking markdown

### DIFF
--- a/src/main/java/ru/rgs/botmon/service/bot/BotMonImpl.java
+++ b/src/main/java/ru/rgs/botmon/service/bot/BotMonImpl.java
@@ -157,6 +157,7 @@ public class BotMonImpl extends TelegramLongPollingBot implements BotMon {
 
     private void sendMessage(long chatId, String text) throws TelegramApiException {
 
+        text = text.replace('_',' ').replace('*',' ').replace('~',' ').replace('`',' ').replace('\\',' ');
         SendMessage message = new SendMessage()
                 .enableMarkdown(true)
                 .setChatId(chatId)


### PR DESCRIPTION
When passing a string containing an underscore, asterisk, or quotation mark to SendMessage, this string must be in the correct markdown format. 
I suggest removing such symbols to avoid confusing behavior.