### PR TITLE
Runner with pid 0 in docker

### DIFF
--- a/dockers/Dockerfile
+++ b/dockers/Dockerfile
@@ -15,13 +15,14 @@ RUN mkdir /usr/local/botmon \
     && mkdir /usr/local/botmon/sqlite \
     && mkdir /usr/local/botmon/run
 
+COPY botmon_entrypoint.sh /usr/local/botmon/
 COPY botmon.sh /usr/local/botmon/
 COPY config /usr/local/botmon/etc/
 COPY botmon.jar /usr/local/botmon/bin/
 
 RUN chmod +x /usr/local/botmon/botmon.sh
 
-ENTRYPOINT /usr/local/botmon/botmon.sh start && tail -f /usr/local/botmon/log/botmon.log
+ENTRYPOINT /usr/local/botmon/botmon_docker.sh
 
 EXPOSE 8226
 

--- a/dockers/botmon_entrypoint.sh
+++ b/dockers/botmon_entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+cd /usr/local/botmon
+
+SCRIPT="${0##*/}"
+SERVICE="${SCRIPT%.*}"
+SERVICE="${SERVICE/_docker/}"
+SERVICE="${SERVICE/_entrypoint/}"
+
+set -o allexport
+source ./etc/config
+LOG_FILE=$SERVICE
+set +o allexport
+
+BINDIR=$ROOTDIR/bin
+OPTIONS="-Xmx400M"
+PIDFILE=./run/$SERVICE.pid
+rm $PIDFILE
+
+if [ ! -d /var/run/$SERVICE_NAME ] ; then
+mkdir /var/run/$SERVICE_NAME
+fi
+
+exec java $OPTIONS -jar $BINDIR/$SERVICE.jar $CONFIG 1 
+


### PR DESCRIPTION
В докере нужно стартовать процесс java через exec чтобы он стал единственным процессом в контейнере с pid 0, тогда docker начинает им правильно управлять.
В существующем до этого варианте контейнер не перестартовывает, т.к. после установки гарантированно остается файл botmon.pid